### PR TITLE
Fixed etflex scores for insulation

### DIFF
--- a/spec/etflex/score_spec.rb
+++ b/spec/etflex/score_spec.rb
@@ -55,13 +55,13 @@ describe "ETFlex Scoring mechanism" do
         @s.households_insulation_level_old_houses = 1.1 #R value
         expect(@s.etflex_score_cost).to increase
       end
-  end
+    end
+    
     describe "Insulation level to R = 3.0" do
       it "should lower your cost score" do
         @s.households_insulation_level_old_houses = 3.0 #R value
         expect(@s.etflex_score_cost).to decrease
       end
-
     end
 
     describe "Electric car share" do


### PR DESCRIPTION
With the new way of modeling insulation, the behavior of the scoring of ETFlex has changed:
- For small values of R (slider setting), the score for costs **improves** (things get cheaper overall)
- For large values, the score worsens

This is due to the non-linear effect of insulation that is now properly taken into account: the costs of insulation scales linearly with R, but the **savings** increase sharply for low R-values and flatten toward higher R-values (see plot).
![snapshot 8 19 13 9 42 am](https://f.cloud.github.com/assets/1303760/984576/e3a201d4-08a2-11e3-93ad-7a56b40ba3d5.png)
So, for small values of R, the savings made with insulation save you money in gas and electricity for heating your home. For large R, the costs of the insulation begin to outweigh the slower increasing savings.

Fixes https://github.com/quintel/mechanical_turk/issues/44
