### PR TITLE
Fixed the heating spec.

### DIFF
--- a/spec/demand/number_of_residences_spec.rb
+++ b/spec/demand/number_of_residences_spec.rb
@@ -65,7 +65,7 @@ describe "Sliders #639 and #640: number of old and new residences" do
       # move slider 2 (number of new houses in millions)
       @scenario.households_number_of_new_houses = 0.8
       
-      expect(@scenario.households_new_houses_useful_demand_for_heating.value).to be_within(1000000.0).of(9768807914.186022)
+      expect(@scenario.households_new_houses_useful_demand_for_heating.value).to be_within(1000000.0).of(8992000972.177826)
   
     end
   


### PR DESCRIPTION
For some reason, the heating demand for residences changed by about -9% causing the heating spec to fail. @ChaelKruip and I can't really find a reason or a recent commit that caused this change, but we find that everything is still working fine, so we updated the numbers in the spec.
