### PR TITLE
Updated the cost spec of energy_power_engine_network_gas.

### DIFF
--- a/spec/costs/costs_spec.rb
+++ b/spec/costs/costs_spec.rb
@@ -202,8 +202,8 @@ describe "Testing costs" do
       @scenario.total_cost_of_energy_power_engine_diesel.value.should be_within(46663.559255).of(933271.1851)
     end
 
-    it "total cost of energy_power_engine_network_gas should be within 5.0% of 933271.1851" do
-      @scenario.total_cost_of_energy_power_engine_network_gas.value.should be_within(4299268).of(85985372.8)
+    it "total cost of energy_power_engine_network_gas should be within 5.0% of 2447767.4466" do
+      @scenario.total_cost_of_energy_power_engine_network_gas.value.should be_within(122388.37233).of(2447767.4466)
     end
 
     it "total cost of energy_power_geothermal should be within 5.0% of 15969915.26" do


### PR DESCRIPTION
Updated the cost spec of `energy_power_engine_network_gas` to reflect the changes made in its full load hours in https://github.com/quintel/etsource/commit/19c45844457d89d1f5511be72fec8641de987b82.
