### PR TITLE
First storage tests

### DIFF
--- a/spec/flexibility/flexibility_spec.rb
+++ b/spec/flexibility/flexibility_spec.rb
@@ -10,7 +10,7 @@ describe "Flexibility" do
     })
   end
 
-  context "P2P" do
+  context "P2P (batteries)" do
   before do
     @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, inputs: {
       settings_enable_merit_order: 1,
@@ -21,10 +21,8 @@ describe "Flexibility" do
    describe "In a scenario increasing the number of P2P units" do
     
      it "should decrease the electricity curtailed" do
-       # Increasing the number of P2P units
        @scenario.households_flexibility_p2p_electricity_market_penetration = 20.0
       
-       # should decrease the electricity curtailed
        expect(@scenario.electricity_curtailed).to decrease
      end
   
@@ -33,10 +31,8 @@ describe "Flexibility" do
     describe "In a scenario increasing the number of P2P units" do
     
      it "should decrease the electricity exported" do
-       # Increasing the number of P2P units
        @scenario.households_flexibility_p2p_electricity_market_penetration = 20.0
       
-       # should decrease the electricity exported
        expect(@scenario.electricity_exported).to decrease
      end
   
@@ -45,16 +41,135 @@ describe "Flexibility" do
     describe "In a scenario increasing the number of P2P units" do
     
      it "should decrease CO2 emissions" do
-       # Increasing the number of P2P units
-       @scenario.households_flexibility_p2p_electricity_market_penetration = 20.0
+       @scenario.households_flexibility_p2p_electricity_market_penetration = 70.0
       
-       # should decrease the CO2 emissions
        expect(@scenario.co2).to decrease
      end
   
     end
 
   end
+
+  context "P2P (electric cars)" do
+  before do
+    @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, inputs: {
+      settings_enable_merit_order: 1,
+      number_of_energy_power_wind_turbine_inland: 10000
+    })
+  end
+
+   describe "In a scenario increasing the availability of electric cars" do
+    
+     it "should decrease the electricity curtailed" do
+       @scenario.transport_car_using_electricity_availability = 20.0
+      
+       expect(@scenario.electricity_curtailed).to decrease
+     end
+  
+   end
+
+    describe "In a scenario increasing the availability of electric cars" do
+    
+     it "should decrease the electricity exported" do
+       @scenario.transport_car_using_electricity_availability = 20.0
+      
+       expect(@scenario.electricity_exported).to decrease
+     end
+  
+   end
+
+    describe "In a scenario increasing the availability of electric cars" do
+    
+     it "should decrease CO2 emissions" do
+       @scenario.transport_car_using_electricity_availability = 20.0
+      
+       expect(@scenario.co2).to decrease
+     end
+  
+    end
+
+  end
+
+  #context "P2H" do
+  #before do
+  #  @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, inputs: {
+  #    settings_enable_merit_order: 1,
+  #    number_of_energy_power_wind_turbine_inland: 10000
+  #  })
+  #end
+
+  # describe "In a scenario increasing the number of P2H units" do
+    
+  #   it "should decrease the electricity curtailed" do
+  #     @scenario.households_flexibility_p2h_electricity_market_penetration = 20.0
+      
+  #     expect(@scenario.electricity_curtailed).to decrease
+  #   end
+  
+  # end
+
+  #  describe "In a scenario increasing the number of P2H units" do
+    
+  #   it "should decrease the electricity exported" do
+  #     @scenario.households_flexibility_p2h_electricity_market_penetration = 20.0
+      
+  #     expect(@scenario.electricity_exported).to decrease
+  #   end
+  
+  # end
+
+  #  describe "In a scenario increasing the number of P2H units" do
+    
+  #   it "should decrease CO2 emissions" do
+  #     @scenario.households_flexibility_p2h_electricity_market_penetration = 20.0
+      
+  #     expect(@scenario.co2).to decrease
+  #   end
+  
+  #  end
+
+  #end
+
+  context "P2G" do
+  before do
+    @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, inputs: {
+      settings_enable_merit_order: 1,
+      number_of_energy_power_wind_turbine_inland: 10000
+    })
+  end
+
+   describe "In a scenario increasing the number of P2G units" do
+    
+     it "should decrease the electricity curtailed" do
+       @scenario.number_of_energy_flexibility_p2g_electricity = 20.0
+      
+       expect(@scenario.electricity_curtailed).to decrease
+     end
+  
+   end
+
+    describe "In a scenario increasing the number of P2G units" do
+    
+     it "should decrease the electricity exported" do
+       @scenario.number_of_energy_flexibility_p2g_electricity = 20.0
+      
+       expect(@scenario.electricity_exported).to decrease
+     end
+  
+   end
+
+  #  describe "In a scenario increasing the number of P2G units" do
+    
+  #   it "should decrease CO2 emissions" do
+  #     @scenario.number_of_energy_flexibility_p2g_electricity = 20.0
+      
+  #     expect(@scenario.co2).to decrease
+  #   end
+  
+  #  end
+
+  end
+
 
 
 # Below is WIP for the flexibility order 

--- a/spec/flexibility/flexibility_spec.rb
+++ b/spec/flexibility/flexibility_spec.rb
@@ -14,7 +14,7 @@ describe "Flexibility" do
   before do
     @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, inputs: {
       settings_enable_merit_order: 1,
-      number_of_energy_power_wind_turbine_inland: 10000
+      number_of_energy_power_wind_turbine_inland: 10000 # excess electricity
     })
   end
 
@@ -54,7 +54,7 @@ describe "Flexibility" do
   before do
     @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, inputs: {
       settings_enable_merit_order: 1,
-      number_of_energy_power_wind_turbine_inland: 10000
+      number_of_energy_power_wind_turbine_inland: 10000 # excess electricity
     })
   end
 
@@ -90,51 +90,52 @@ describe "Flexibility" do
 
   end
 
-  #context "P2H" do
-  #before do
-  #  @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, inputs: {
-  #    settings_enable_merit_order: 1,
-  #    number_of_energy_power_wind_turbine_inland: 10000
-  #  })
-  #end
+  context "P2H" do
+  before do
+    @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, inputs: {
+      settings_enable_merit_order: 1,
+      number_of_energy_power_wind_turbine_inland: 10000 # excess electricity
+    })
+  end
 
-  # describe "In a scenario increasing the number of P2H units" do
+   describe "In a scenario increasing the number of P2H units" do
     
-  #   it "should decrease the electricity curtailed" do
-  #     @scenario.households_flexibility_p2h_electricity_market_penetration = 20.0
+     it "should decrease the electricity curtailed" do
+       @scenario.households_flexibility_p2h_electricity_market_penetration = 20.0
       
-  #     expect(@scenario.electricity_curtailed).to decrease
-  #   end
+       expect(@scenario.electricity_curtailed).to decrease
+     end
   
-  # end
+   end
 
-  #  describe "In a scenario increasing the number of P2H units" do
+    describe "In a scenario increasing the number of P2H units" do
     
-  #   it "should decrease the electricity exported" do
-  #     @scenario.households_flexibility_p2h_electricity_market_penetration = 20.0
+     it "should decrease the electricity exported" do
+       @scenario.households_flexibility_p2h_electricity_market_penetration = 20.0
       
-  #     expect(@scenario.electricity_exported).to decrease
-  #   end
+       expect(@scenario.electricity_exported).to decrease
+     end
   
-  # end
+   end
 
-  #  describe "In a scenario increasing the number of P2H units" do
+    describe "In a scenario increasing the number of P2H units" do
     
-  #   it "should decrease CO2 emissions" do
-  #     @scenario.households_flexibility_p2h_electricity_market_penetration = 20.0
+     it "should decrease CO2 emissions" do
+       @scenario.households_flexibility_p2h_electricity_market_penetration = 20.0
       
-  #     expect(@scenario.co2).to decrease
-  #   end
+       expect(@scenario.co2).to decrease
+     end
   
-  #  end
+    end
 
-  #end
+  end
 
   context "P2G" do
   before do
     @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, inputs: {
       settings_enable_merit_order: 1,
-      number_of_energy_power_wind_turbine_inland: 10000
+      number_of_energy_power_wind_turbine_inland: 10000, # excess electricity
+      transport_car_using_hydrogen_share: 20.0 #making sure there are hydrogen cars
     })
   end
 
@@ -158,15 +159,15 @@ describe "Flexibility" do
   
    end
 
-  #  describe "In a scenario increasing the number of P2G units" do
+    describe "In a scenario increasing the number of P2G units" do
     
-  #   it "should decrease CO2 emissions" do
-  #     @scenario.number_of_energy_flexibility_p2g_electricity = 20.0
+     it "should decrease CO2 emissions" do
+       @scenario.number_of_energy_flexibility_p2g_electricity = 200.0
       
-  #     expect(@scenario.co2).to decrease
-  #   end
+       expect(@scenario.co2).to decrease
+     end
   
-  #  end
+    end
 
   end
 

--- a/spec/flexibility/flexibility_spec.rb
+++ b/spec/flexibility/flexibility_spec.rb
@@ -1,0 +1,89 @@
+# Relevant sliders #661-671
+
+require 'spec_helper'
+
+describe "Flexibility" do
+
+  before do
+    @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, inputs: {
+      settings_enable_merit_order: 1 
+    })
+  end
+
+  context "P2P" do
+  before do
+    @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, inputs: {
+      settings_enable_merit_order: 1,
+      number_of_energy_power_wind_turbine_inland: 10000
+    })
+  end
+
+   describe "In a scenario increasing the number of P2P units" do
+    
+     it "should decrease the electricity curtailed" do
+       # Increasing the number of P2P units
+       @scenario.households_flexibility_p2p_electricity_market_penetration = 20.0
+      
+       # should decrease the electricity curtailed
+       expect(@scenario.electricity_curtailed).to decrease
+     end
+  
+   end
+
+    describe "In a scenario increasing the number of P2P units" do
+    
+     it "should decrease the electricity exported" do
+       # Increasing the number of P2P units
+       @scenario.households_flexibility_p2p_electricity_market_penetration = 20.0
+      
+       # should decrease the electricity exported
+       expect(@scenario.electricity_exported).to decrease
+     end
+  
+   end
+
+    describe "In a scenario increasing the number of P2P units" do
+    
+     it "should decrease CO2 emissions" do
+       # Increasing the number of P2P units
+       @scenario.households_flexibility_p2p_electricity_market_penetration = 20.0
+      
+       # should decrease the CO2 emissions
+       expect(@scenario.co2).to decrease
+     end
+  
+    end
+
+  end
+
+
+# Below is WIP for the flexibility order 
+# which requires an extension of the ETE ConverterApi
+
+
+
+  #context "Flexibility order" do
+  #before do
+  #  @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, inputs: {
+  #    settings_enable_merit_order: 1,
+  #    households_flexibility_p2h_electricity_market_penetration: 20.0
+  #  })
+  #end
+
+   #describe "Putting P2H first in the flexibility options" do
+
+    # it "should decrease the hot water demand" do
+
+       # increasing the amount of LNG that is regasified and fed into the gas grid
+       #@scenario.update_flexibility_order = {order: ['p2h', 'p2g']}
+    #   FlexibilityOrder.create!(order: ['p2h', 'p2g'])
+
+       # should result in an increase in the number_of_units of regasification converters
+     #  expect(@scenario.final_demand_of_heat_in_households).to decrease
+     #end
+  
+   #end
+
+  #end
+
+end


### PR DESCRIPTION
See #84 and the follow up ticket that will reference this ticket.

Checks if increasing the NoU decreases electricity curtailed, electricity exported and CO2 emissions for all storage technologies. All tests pass as of now.