### PR TITLE
Enable pending tests

### DIFF
--- a/spec/costs/costs_spec.rb
+++ b/spec/costs/costs_spec.rb
@@ -453,12 +453,6 @@ describe "Testing costs" do
     it "total cost of other_burner_wood_pellets should be within 1.0% of 510287.1814" do
         @scenario.total_cost_of_other_burner_wood_pellets.value.should be_within(5102.871814).of(510287.1814)
     end
-    xit "total cost of transport_car_using_electricity should be within 1.0% of 0.0" do
-        @scenario.total_cost_of_transport_car_using_electricity.value.should be_within(0.0).of(0.0)
-    end
-    xit "total cost of transport_car_using_hydrogen should be within 1.0% of 0.0" do
-        @scenario.total_cost_of_transport_car_using_hydrogen.value.should be_within(0.0).of(0.0)
-    end
 
   end
 end

--- a/spec/demand/lng_spec.rb
+++ b/spec/demand/lng_spec.rb
@@ -11,33 +11,33 @@ describe "LNG" do
   context "Scenarios which start with 100% LNG regasification" do
   before do
     @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, inputs: {
-      energy_regasification_lng_share: 100.0 
+      energy_regasification_lng_share: 100.0
     })
   end
 
    describe "In a scenario in which all natural gas is regasified LNG" do
-    
+
      it "changing the pipeline natural gas FCE shouldn't change CO2 emissions" do
        # Importing all LNG from Norway
        @scenario.gas_from_norway_share = 100.0
-      
+
        # shouldn't change anything if no LNG is imported at all
        expect(@scenario.co2.increase).to be == 0
      end
-  
+
    end
 
    describe "In a scenario in which all natural gas is regasified LNG" do
-    
-     xit "importing all LNG from Qatar should increase CO2 emissions" do
+
+     it "importing all LNG from Qatar should increase CO2 emissions" do
        # Importing all LNG from Qatar (highest co2_per_mj attributes)
        @scenario.lng_from_qatar_share = 100.0
-      
+
        # should increase CO2 emissions in transport and in total
        expect(@scenario.co2).to increase
        expect(@scenario.primary_co2_of_natural_gas_and_derivatives_in_transport).to increase
      end
-  
+
    end
 
   end
@@ -57,11 +57,11 @@ describe "LNG" do
      it "changing the LNG FCEs shouldn't change CO2 emissions" do
        #if there is no LNG flow but there is bio LNG in transport, changing the FCEs
        @scenario.lng_from_algeria_share = 100.0
-      
+
        # shouldn't change the co2 emissions (since bio LNG shouldn't be affected either)
        expect(@scenario.co2.increase).to be == 0
      end
-  
+
    end
 
    describe "In a scenario in which more LNG is regasified" do
@@ -71,11 +71,11 @@ describe "LNG" do
        # increasing the amount of LNG that is regasified and fed into the gas grid
        @scenario.energy_treatment_natural_gas_share = 80.0
        @scenario.energy_regasification_lng_share = 20.0
-      
+
        # should result in an increase in the number_of_units of regasification converters
        expect(@scenario.turk_regasification_lng_number).to increase
      end
-  
+
    end
 
   end

--- a/spec/flexibility/flexibility_spec.rb
+++ b/spec/flexibility/flexibility_spec.rb
@@ -290,10 +290,10 @@ context "P2H for industry" do
     end
 
 
-       describe "In a scenario with excess electricity increasing the number of P2H units in the paper sector" do
+    describe "In a scenario with excess electricity increasing the number of P2H units in the paper sector" do
 
-     xit "should decrease the electricity curtailed" do
-       @scenario.number_of_industry_other_paper_flexibility_p2h_electricity = 10.0
+     it "should decrease the electricity curtailed" do
+       @scenario.number_of_industry_other_paper_flexibility_p2h_electricity = 8.0
 
        expect(@scenario.electricity_curtailed).to decrease
      end
@@ -301,8 +301,8 @@ context "P2H for industry" do
 
     describe "In a scenario with excess electricity increasing the number of P2H units in the paper sector" do
 
-     xit "should decrease the electricity exported" do
-       @scenario.number_of_industry_other_paper_flexibility_p2h_electricity = 10.0
+     it "should decrease the electricity exported" do
+       @scenario.number_of_industry_other_paper_flexibility_p2h_electricity = 8.0
 
        expect(@scenario.electricity_exported).to decrease
      end
@@ -310,8 +310,8 @@ context "P2H for industry" do
 
     describe "In a scenario with excess electricity increasing the number of P2H units in the paper sector" do
 
-     xit "should decrease CO2 emissions" do
-       @scenario.number_of_industry_other_paper_flexibility_p2h_electricity = 10.0
+     it "should decrease CO2 emissions" do
+       @scenario.number_of_industry_other_paper_flexibility_p2h_electricity = 8.0
 
        expect(@scenario.co2).to decrease
      end
@@ -320,8 +320,8 @@ context "P2H for industry" do
 
     describe "In a scenario with excess electricity increasing the number of P2H units in the paper sector" do
 
-     xit "should decrease the gas use of that sector" do
-       @scenario.number_of_industry_other_paper_flexibility_p2h_electricity = 10.0
+     it "should decrease the gas use of that sector" do
+       @scenario.number_of_industry_other_paper_flexibility_p2h_electricity = 8.0
 
        expect(@scenario.final_demand_of_natural_gas_and_derivatives_in_paper_industry_energetic).to decrease
      end
@@ -395,8 +395,10 @@ context "P2H for industry" do
   before do
     @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, autobalance: true, inputs: {
       settings_enable_merit_order: 1,
-      households_useful_demand_heat_per_person: 5.0, # excess electricity
-      households_useful_demand_hot_water_share: 5.0, # making sure there are hydrogen cars
+      households_useful_demand_heat_per_person: 5.0, # excess heat demand
+      households_useful_demand_hot_water_share: 5.0, # excess hot water demand
+      households_flexibility_water_heating_buffer_size_heatpump_air_water_electricity: 0.0, # remove buffer
+      households_flexibility_water_heating_buffer_size_heatpump_ground_water_electricity: 0.0, # remove buffer
       households_heater_heatpump_air_water_electricity_share: 100.0
     })
   end
@@ -406,18 +408,16 @@ context "P2H for industry" do
      it "should decrease the deficits" do
       @scenario.households_flexibility_space_heating_buffer_size_heatpump_air_water_electricity = 250.0
 
-
       expect(@scenario.households_space_heater_heatpump_air_water_electricity_deficit).to decrease
      end
 
-   end
+    end
 
 
    describe "In a scenario with deficits and 100"%" heat pump air increasing the water heating buffer size" do
 
-     xit "should decrease the deficits" do
+     it "should decrease the deficits" do
       @scenario.households_flexibility_water_heating_buffer_size_heatpump_air_water_electricity = 250.0
-
 
       expect(@scenario.households_water_heater_heatpump_air_water_electricity_deficit).to decrease
      end


### PR DESCRIPTION
Fixes https://github.com/quintel/mechanical_turk/issues/100:
- Enable pending flexibility tests by changing the slider inputs (e.g., 10.0 is greater than the max (= 8.2) of the `number_of_industry_other_paper_flexibility_p2h_electricity`slider)
- Enable pending test for LNG
- Remove pending costs tests for cars since these have zero costs (nor corresponding queries)