### PR TITLE
Fix specs after updating the hourly curves

### DIFF
--- a/spec/costs/costs_spec.rb
+++ b/spec/costs/costs_spec.rb
@@ -156,8 +156,8 @@ describe "Testing costs" do
     it "total cost of energy_power_combined_cycle_coal should be within 1.0% of 157393563.7" do
         @scenario.total_cost_of_energy_power_combined_cycle_coal.value.should be_within(1573935.6369999999).of(157393563.7)
     end
-    it "total cost of energy_power_combined_cycle_network_gas should be within 1.0% of 180803216.4" do
-        @scenario.total_cost_of_energy_power_combined_cycle_network_gas.value.should be_within(1808032.164).of(180803216.4)
+    it "total cost of energy_power_combined_cycle_network_gas should be within 1.0% of 176668228.2" do
+        @scenario.total_cost_of_energy_power_combined_cycle_network_gas.value.should be_within(1766682.282).of(176668228.2)
     end
     it "total cost of energy_power_engine_diesel should be within 1.0% of 34000.0" do
         @scenario.total_cost_of_energy_power_engine_diesel.value.should be_within(340.0).of(34000.0)

--- a/spec/demand/hybrid_heatpump_spec.rb
+++ b/spec/demand/hybrid_heatpump_spec.rb
@@ -115,11 +115,11 @@ describe "Hybrid heat pump" do
 
         # we expect the gas share to decrease due to insulation and
         # the decrease in number of houses (and hence, a decrease in network gas demand)
-        expect(@scenario.turk_hhp_network_gas_input_share.increase).to be_within(1.0E-12).of -0.005274387719
+        expect(@scenario.turk_hhp_network_gas_input_share.increase).to be_within(1.0E-12).of -0.005555479398
         # then the ambient_heat and electricity share grow by this value, distributed in agreement with the COP
         # the small window of 1.0E-12 is there because of the COP calculation
-        expect(@scenario.turk_hhp_electricity_input_share.increase).to be_within(1.0E-12).of 0.001460621306
-        expect(@scenario.turk_hhp_ambient_heat_input_share.increase).to be_within(1.0E-12).of 0.003813766413
+        expect(@scenario.turk_hhp_electricity_input_share.increase).to be_within(1.0E-12).of 0.001556406394
+        expect(@scenario.turk_hhp_ambient_heat_input_share.increase).to be_within(1.0E-12).of 0.003999073003
       end
     end
   end

--- a/spec/flexibility/flexibility_spec.rb
+++ b/spec/flexibility/flexibility_spec.rb
@@ -413,10 +413,10 @@ context "P2H for industry" do
 
     end
 
-
+   # 2019-06: After the curves update, there are no households water heater deficits anymore, which makes this spec redundant at the moment 
    describe "In a scenario with deficits and 100"%" heat pump air increasing the water heating buffer size" do
 
-     it "should decrease the deficits" do
+     xit "should decrease the deficits" do
       @scenario.households_flexibility_water_heating_buffer_size_heatpump_air_water_electricity = 250.0
 
       expect(@scenario.households_water_heater_heatpump_air_water_electricity_deficit).to decrease


### PR DESCRIPTION
- The total cost per `energy_power_combined_cycle_network_gas` plant has decreased, probably because of a decrease in full load hours due to the updated curves. When the FLH are compared between LIVE and BETA scenarios for NL 2015, it is indeed the case that the node has fewer FLH in the BETA NL 2050 scenario compared to the LIVE NL 2050 scenario.
- The future input shares of the HHP have been changed due to the updated heat curves (`insulation_apartments_high.csv`, etc) which have changed due to the updated `air_temperature.csv` curve.
- In an extreme scenario (in which there is an excessive hot water demand, heat pumps are used for the hot water demand, and a heat pump buffer size of 0) there seem to be zero households hot water deficits. When comparing the old and new hourly curves for hot water (electricity) demand, the new curve indeed has lower peaks compared to the old one. Increasing the buffer size obviously still results in zero deficits, which is why I disabled the spec for now.