### PR TITLE
Fix specs after iNET changes 

### DIFF
--- a/spec/climate_slider/climate_spec.rb
+++ b/spec/climate_slider/climate_spec.rb
@@ -13,7 +13,7 @@ describe "Testing climate slider" do
       demand_before_update = @scenario.households_apartments_useful_demand_for_space_heating.future
       #pp demand_before_update
 
-      @scenario.households_climate_influence = 5.0 # degrees centigrade
+      @scenario.flexibility_outdoor_temperature = 5.0 # degrees centigrade
 
       demand_after_update = @scenario.households_apartments_useful_demand_for_space_heating.future
       #pp demand_after_update
@@ -27,7 +27,7 @@ describe "Testing climate slider" do
       demand_before_update = @scenario.households_apartments_useful_demand_for_space_heating.future
       #pp demand_before_update
 
-      @scenario.households_climate_influence = -5.0 # degrees centigrade
+      @scenario.flexibility_outdoor_temperature = -5.0 # degrees centigrade
 
       demand_after_update = @scenario.households_apartments_useful_demand_for_space_heating.future
       #pp demand_after_update
@@ -41,7 +41,7 @@ describe "Testing climate slider" do
       demand_before_update = @scenario.households_useful_demand_for_cooling.future
       #pp demand_before_update
 
-      @scenario.households_climate_influence = 5.0 # degrees centigrade
+      @scenario.flexibility_outdoor_temperature = 5.0 # degrees centigrade
 
       demand_after_update = @scenario.households_useful_demand_for_cooling.future
       #pp demand_after_update
@@ -55,7 +55,7 @@ describe "Testing climate slider" do
       demand_before_update =  @scenario.households_useful_demand_for_cooling.future
       #pp demand_before_update
 
-      @scenario.households_climate_influence = -5.0 # degrees centigrade
+      @scenario.flexibility_outdoor_temperature = -5.0 # degrees centigrade
 
       demand_after_update = @scenario.households_useful_demand_for_cooling.future
       #pp demand_after_update

--- a/spec/costs/costs_spec.rb
+++ b/spec/costs/costs_spec.rb
@@ -348,8 +348,11 @@ describe "Testing costs" do
     it "total cost of industry_chemicals_other_burner_wood_pellets should be within 1.0% of 10641566.0016" do
         @scenario.total_cost_of_industry_chemicals_other_burner_wood_pellets.value.should be_within(106415.66001611115).of(10641566.001611115)
     end
-    it "total cost of industry_chemicals_other_flexibility_p2h_electricity should be within 1.0% of 400000.0" do
-        @scenario.total_cost_of_industry_chemicals_other_flexibility_p2h_electricity.value.should be_within(4000.0).of(400000.0)
+    it "total cost of industry_chemicals_other_flexibility_p2h_network_gas_electricity should be within 1.0% of 400000.0" do
+        @scenario.total_cost_of_industry_chemicals_other_flexibility_p2h_network_gas_electricity.value.should be_within(4000.0).of(400000.0)
+    end
+    it "total cost of industry_chemicals_other_flexibility_p2h_hydrogen_electricity should be within 1.0% of 400000.0" do
+        @scenario.total_cost_of_industry_chemicals_other_flexibility_p2h_hydrogen_electricity.value.should be_within(4000.0).of(400000.0)
     end
     it "total cost of industry_chemicals_other_heater_electricity should be within 1.0% of 454750.0" do
         @scenario.total_cost_of_industry_chemicals_other_heater_electricity.value.should be_within(4547.5).of(454750.0)
@@ -375,8 +378,11 @@ describe "Testing costs" do
     it "total cost of industry_chemicals_refineries_burner_wood_pellets should be within 1.0% of 10641566.0016" do
         @scenario.total_cost_of_industry_chemicals_refineries_burner_wood_pellets.value.should be_within(106415.66001611115).of(10641566.001611115)
     end
-    it "total cost of industry_chemicals_refineries_flexibility_p2h_electricity should be within 1.0% of 400000.0" do
-        @scenario.total_cost_of_industry_chemicals_refineries_flexibility_p2h_electricity.value.should be_within(4000.0).of(400000.0)
+    it "total cost of industry_chemicals_refineries_flexibility_p2h_network_gas_electricity should be within 1.0% of 400000.0" do
+        @scenario.total_cost_of_industry_chemicals_refineries_flexibility_p2h_network_gas_electricity.value.should be_within(4000.0).of(400000.0)
+    end
+    it "total cost of industry_chemicals_refineries_flexibility_p2h_hydrogen_electricity should be within 1.0% of 400000.0" do
+        @scenario.total_cost_of_industry_chemicals_refineries_flexibility_p2h_hydrogen_electricity.value.should be_within(4000.0).of(400000.0)
     end
     it "total cost of industry_chp_combined_cycle_gas_power_fuelmix should be within 1.0% of 19071729.92" do
         @scenario.total_cost_of_industry_chp_combined_cycle_gas_power_fuelmix.value.should be_within(190717.2992).of(19071729.92)
@@ -405,8 +411,11 @@ describe "Testing costs" do
     it "total cost of industry_other_food_burner_wood_pellets should be within 1.0% of 10641566.0016" do
         @scenario.total_cost_of_industry_other_food_burner_wood_pellets.value.should be_within(106415.66001611115).of(10641566.001611115)
     end
-    it "total cost of industry_other_food_flexibility_p2h_electricity should be within 1.0% of 400000.0" do
-        @scenario.total_cost_of_industry_other_food_flexibility_p2h_electricity.value.should be_within(4000.0).of(400000.0)
+    it "total cost of industry_other_food_flexibility_p2h_network_gas_electricity should be within 1.0% of 400000.0" do
+        @scenario.total_cost_of_industry_other_food_flexibility_p2h_network_gas_electricity.value.should be_within(4000.0).of(400000.0)
+    end
+    it "total cost of industry_other_food_flexibility_p2h_hydrogen_electricity should be within 1.0% of 400000.0" do
+        @scenario.total_cost_of_industry_other_food_flexibility_p2h_hydrogen_electricity.value.should be_within(4000.0).of(400000.0)
     end
     it "total cost of industry_other_food_heater_electricity should be within 1.0% of 454750.0" do
         @scenario.total_cost_of_industry_other_food_heater_electricity.value.should be_within(4547.5).of(454750.0)
@@ -429,8 +438,11 @@ describe "Testing costs" do
     it "total cost of industry_other_paper_burner_wood_pellets should be within 1.0% of 10641566.0016" do
         @scenario.total_cost_of_industry_other_paper_burner_wood_pellets.value.should be_within(106415.66001611115).of(10641566.001611115)
     end
-    it "total cost of industry_other_paper_flexibility_p2h_electricity should be within 1.0% of 400000.0" do
-        @scenario.total_cost_of_industry_other_paper_flexibility_p2h_electricity.value.should be_within(4000.0).of(400000.0)
+    it "total cost of industry_other_paper_flexibility_p2h_network_gas_electricity should be within 1.0% of 400000.0" do
+        @scenario.total_cost_of_industry_other_paper_flexibility_p2h_network_gas_electricity.value.should be_within(4000.0).of(400000.0)
+    end
+    it "total cost of industry_other_paper_flexibility_p2h_hydrogen_electricity should be within 1.0% of 400000.0" do
+        @scenario.total_cost_of_industry_other_paper_flexibility_p2h_hydrogen_electricity.value.should be_within(4000.0).of(400000.0)
     end
     it "total cost of industry_other_paper_heater_electricity should be within 1.0% of 454750.0" do
         @scenario.total_cost_of_industry_other_paper_heater_electricity.value.should be_within(4547.5).of(454750.0)

--- a/spec/demand/hybrid_heatpump_spec.rb
+++ b/spec/demand/hybrid_heatpump_spec.rb
@@ -173,8 +173,7 @@ describe "Hybrid heat pump" do
 
     describe "Changing to space heating profile 1987 and adjusting outdoor termperature accordingly" do
       it "should result in more gas use by HHP's" do
-       @scenario.settings_heat_curve_set = 1.0
-       @scenario.households_climate_influence = -2.0
+       @scenario.settings_weather_curve_set = 1987
 
        expect(@scenario.turk_hhp_network_gas_input_share).to increase
       end


### PR DESCRIPTION
Fixed specs for the following changes:
- The input `households_climate_influence` was renamed to `flexibility_outdoor_temperature`.
- The input `settings_heat_curve_set` was renamed to `settings_weather_curve_set` and now requires years (instead of a binary number) as input. Setting a year other than default results in a disabled `flexibility_outdoor_temperature` input.
- We now distinguish network gas and hydrogen p2h converters in industry (instead of a generic one). 