### PR TITLE
Update which power plants are turned off to create nonzero LOLE

### DIFF
--- a/spec/lole/lole_spec.rb
+++ b/spec/lole/lole_spec.rb
@@ -8,10 +8,9 @@ describe "Starting with a scenario with nonzero LOLE," do
 
   before(:each) do
     @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, inputs: {
-      # removing all the Gas CCGT to create a nonzero LOLP
+      # removing all the Gas CCGT and Pulverized coal to create a nonzero LOLP
       capacity_of_energy_power_combined_cycle_network_gas: 0.0,
-      # removing all Gas CHP to increase LOLP
-      capacity_of_energy_chp_combined_cycle_network_gas: 0.0
+      capacity_of_energy_power_ultra_supercritical_coal: 0.0,
     })
   end
 

--- a/spec/lole/lole_spec.rb
+++ b/spec/lole/lole_spec.rb
@@ -10,7 +10,7 @@ describe "Starting with a scenario with nonzero LOLE," do
     @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, inputs: {
       # removing all the Gas CCGT and Pulverized coal to create a nonzero LOLP
       capacity_of_energy_power_combined_cycle_network_gas: 0.0,
-      capacity_of_energy_power_ultra_supercritical_coal: 0.0,
+      capacity_of_energy_power_ultra_supercritical_coal: 0.0
     })
   end
 


### PR DESCRIPTION
Due to an update of a number of electricity demand profiles, the peaks in total electricity demand were lowered. This caused the LOLE to remain 0 even when Gas CCGT and Gas CHP were removed from a blank scenario. To create a nonzero LOLE from a blank scenario, Pulverized coal and Gas CCGT are now removed instead.