### PR TITLE
Add spec to test electricity mix for power-to-gas chart input series

### DIFF
--- a/spec/flexibility/power_to_gas_spec.rb
+++ b/spec/flexibility/power_to_gas_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Input of power-to-gas' do
+  Turk::PresetCollection.from_keys(:ii3050, :nvdt, :scenario_collection, :merit_off).each do |scenario|
+    context "with scenario #{scenario.original_scenario_id}" do
+      # Test whether electricity mix input of power-to-gas sums to total demand
+      it 'Sum of series in the electricity mix for power-to-gas chart should match total demand of the node' do
+        expect(
+          scenario.turk_power_to_gas_electricity_demand
+        ).to softly_equal(
+          scenario.turk_power_to_gas_electricity_mix_input
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a test that verifies whether the input series in the chart "Electricity mix for power-to-gas" sum to the total demand of the node.

This PR is dependent on the queries in https://github.com/quintel/etsource/pull/2801

<img width="500" alt="Screenshot 2022-11-08 at 09 50 39" src="https://user-images.githubusercontent.com/67338510/200518488-3fc23477-5227-4be2-a9fc-c7bf698f2235.png">