### PR TITLE
Heat modelling changes for the built environment

### DIFF
--- a/spec/demand/hybrid_heatpump_spec.rb
+++ b/spec/demand/hybrid_heatpump_spec.rb
@@ -13,7 +13,30 @@ describe "Hybrid heat pump" do
 
       it "should give the initial input shares" do
         # destroying all houses
-        @scenario.households_number_of_residences = 0.0
+        @scenario.households_number_of_apartments_before_1945 = 0.0
+        @scenario.households_number_of_apartments_1945_1964 = 0.0
+        @scenario.households_number_of_apartments_1965_1984 = 0.0
+        @scenario.households_number_of_apartments_1985_2004 = 0.0
+        @scenario.households_number_of_apartments_2005_present = 0.0
+        @scenario.households_number_of_apartments_future = 0.0
+        @scenario.households_number_of_detached_houses_before_1945 = 0.0
+        @scenario.households_number_of_detached_houses_1945_1964 = 0.0
+        @scenario.households_number_of_detached_houses_1965_1984 = 0.0
+        @scenario.households_number_of_detached_houses_1985_2004 = 0.0
+        @scenario.households_number_of_detached_houses_2005_present = 0.0
+        @scenario.households_number_of_detached_houses_future = 0.0
+        @scenario.households_number_of_semi_detached_houses_before_1945 = 0.0
+        @scenario.households_number_of_semi_detached_houses_1945_1964 = 0.0
+        @scenario.households_number_of_semi_detached_houses_1965_1984 = 0.0
+        @scenario.households_number_of_semi_detached_houses_1985_2004 = 0.0
+        @scenario.households_number_of_semi_detached_houses_2005_present = 0.0
+        @scenario.households_number_of_semi_detached_houses_future = 0.0
+        @scenario.households_number_of_terraced_houses_before_1945 = 0.0
+        @scenario.households_number_of_terraced_houses_1945_1964 = 0.0
+        @scenario.households_number_of_terraced_houses_1965_1984 = 0.0
+        @scenario.households_number_of_terraced_houses_1985_2004 = 0.0
+        @scenario.households_number_of_terraced_houses_2005_present = 0.0
+        @scenario.households_number_of_terraced_houses_future = 0.0
 
         # should give us the initial input shares
         expect(@scenario.turk_hhp_network_gas_input_share.increase).to be == 0.0
@@ -28,16 +51,50 @@ describe "Hybrid heat pump" do
 
       it "should not change the HHP's COP" do
         # move residence sliders
-        @scenario.households_number_of_residences = 9.2E6
+        @scenario.households_number_of_apartments_before_1945 = 516342 * 0.9
+        @scenario.households_number_of_apartments_1945_1964 = 371806 * 0.9
+        @scenario.households_number_of_apartments_1965_1984 = 729999 * 0.9
+        @scenario.households_number_of_apartments_1985_2004 = 591948 * 0.9
+        @scenario.households_number_of_apartments_2005_present = 466180 * 0.9
+        @scenario.households_number_of_detached_houses_before_1945 = 178650 * 0.9
+        @scenario.households_number_of_detached_houses_1945_1964 = 175973 * 0.9
+        @scenario.households_number_of_detached_houses_1965_1984 = 333220 * 0.9
+        @scenario.households_number_of_detached_houses_1985_2004 = 223668 * 0.9
+        @scenario.households_number_of_detached_houses_2005_present = 105276 * 0.9
+        @scenario.households_number_of_semi_detached_houses_before_1945 = 237409 * 0.9
+        @scenario.households_number_of_semi_detached_houses_1945_1964 = 214301 * 0.9
+        @scenario.households_number_of_semi_detached_houses_1965_1984 = 606264 * 0.9
+        @scenario.households_number_of_semi_detached_houses_1985_2004 = 416081 * 0.9
+        @scenario.households_number_of_semi_detached_houses_2005_present = 173292 * 0.9
+        @scenario.households_number_of_terraced_houses_before_1945 = 622120 * 0.9
+        @scenario.households_number_of_terraced_houses_1945_1964 = 312200 * 0.9
+        @scenario.households_number_of_terraced_houses_1965_1984 = 504251 * 0.9
+        @scenario.households_number_of_terraced_houses_1985_2004 = 550888 * 0.9
+        @scenario.households_number_of_terraced_houses_2005_present = 258096 * 0.9
 
         # move insulation sliders
-        @scenario.households_insulation_level_apartments = 14
-        @scenario.households_insulation_level_corner_houses = 12
-        @scenario.households_insulation_level_detached_houses = 15
-        @scenario.households_insulation_level_semi_detached_houses = 17
-        @scenario.households_insulation_level_terraced_houses = 16
+        @scenario.households_insulation_level_apartments_before_1945 = 309.2785 * 0.9
+        @scenario.households_insulation_level_apartments_1945_1964 = 225.7048 * 0.9
+        @scenario.households_insulation_level_apartments_1965_1984 = 193.542 * 0.9
+        @scenario.households_insulation_level_apartments_1985_2004 = 154.5946 * 0.9
+        @scenario.households_insulation_level_apartments_2005_present = 115.9263 * 0.9
+        @scenario.households_insulation_level_detached_houses_before_1945 = 296.1239 * 0.9
+        @scenario.households_insulation_level_detached_houses_1945_1964 = 243.2537 * 0.9
+        @scenario.households_insulation_level_detached_houses_1965_1984 = 202.5222 * 0.9
+        @scenario.households_insulation_level_detached_houses_1985_2004 = 160.3984 * 0.9
+        @scenario.households_insulation_level_detached_houses_2005_present = 116.3707 * 0.9
+        @scenario.households_insulation_level_semi_detached_houses_before_1945 = 268.9665 * 0.9
+        @scenario.households_insulation_level_semi_detached_houses_1945_1964 = 217.0396 * 0.9
+        @scenario.households_insulation_level_semi_detached_houses_1965_1984 = 187.3579 * 0.9
+        @scenario.households_insulation_level_semi_detached_houses_1985_2004 = 154.0974 * 0.9
+        @scenario.households_insulation_level_semi_detached_houses_2005_present = 114.2388 * 0.9
+        @scenario.households_insulation_level_terraced_houses_before_1945 = 305.0056 * 0.9
+        @scenario.households_insulation_level_terraced_houses_1945_1964 = 280.6464 * 0.9
+        @scenario.households_insulation_level_terraced_houses_1965_1984 = 217.9607 * 0.9
+        @scenario.households_insulation_level_terraced_houses_1985_2004 = 150.8078 * 0.9
+        @scenario.households_insulation_level_terraced_houses_2005_present = 116.2858 * 0.9
 
-        # then we expect the COP to stay constant (but we have a very small change, see line 21-22)
+        # then we expect the COP to stay constant (but we have a very small change, see line 44-45)
         expect(@scenario.turk_hhp_cop_constant.increase).to be < 1.0E-12
       end
     end
@@ -46,29 +103,97 @@ describe "Hybrid heat pump" do
 
       it "should return the initial shares" do
         # move residence sliders
-        @scenario.households_number_of_residences = 9.2E6
+        @scenario.households_number_of_apartments_before_1945 = 516342 * 0.9
+        @scenario.households_number_of_apartments_1945_1964 = 371806 * 0.9
+        @scenario.households_number_of_apartments_1965_1984 = 729999 * 0.9
+        @scenario.households_number_of_apartments_1985_2004 = 591948 * 0.9
+        @scenario.households_number_of_apartments_2005_present = 466180 * 0.9
+        @scenario.households_number_of_detached_houses_before_1945 = 178650 * 0.9
+        @scenario.households_number_of_detached_houses_1945_1964 = 175973 * 0.9
+        @scenario.households_number_of_detached_houses_1965_1984 = 333220 * 0.9
+        @scenario.households_number_of_detached_houses_1985_2004 = 223668 * 0.9
+        @scenario.households_number_of_detached_houses_2005_present = 105276 * 0.9
+        @scenario.households_number_of_semi_detached_houses_before_1945 = 237409 * 0.9
+        @scenario.households_number_of_semi_detached_houses_1945_1964 = 214301 * 0.9
+        @scenario.households_number_of_semi_detached_houses_1965_1984 = 606264 * 0.9
+        @scenario.households_number_of_semi_detached_houses_1985_2004 = 416081 * 0.9
+        @scenario.households_number_of_semi_detached_houses_2005_present = 173292 * 0.9
+        @scenario.households_number_of_terraced_houses_before_1945 = 622120 * 0.9
+        @scenario.households_number_of_terraced_houses_1945_1964 = 312200 * 0.9
+        @scenario.households_number_of_terraced_houses_1965_1984 = 504251 * 0.9
+        @scenario.households_number_of_terraced_houses_1985_2004 = 550888 * 0.9
+        @scenario.households_number_of_terraced_houses_2005_present = 258096 * 0.9
 
         # move insulation sliders
-        @scenario.households_insulation_level_apartments = 14
-        @scenario.households_insulation_level_corner_houses = 12
-        @scenario.households_insulation_level_detached_houses = 15
-        @scenario.households_insulation_level_semi_detached_houses = 17
-        @scenario.households_insulation_level_terraced_houses = 16
+        @scenario.households_insulation_level_apartments_before_1945 = 309.2785 * 0.9
+        @scenario.households_insulation_level_apartments_1945_1964 = 225.7048 * 0.9
+        @scenario.households_insulation_level_apartments_1965_1984 = 193.542 * 0.9
+        @scenario.households_insulation_level_apartments_1985_2004 = 154.5946 * 0.9
+        @scenario.households_insulation_level_apartments_2005_present = 115.9263 * 0.9
+        @scenario.households_insulation_level_detached_houses_before_1945 = 296.1239 * 0.9
+        @scenario.households_insulation_level_detached_houses_1945_1964 = 243.2537 * 0.9
+        @scenario.households_insulation_level_detached_houses_1965_1984 = 202.5222 * 0.9
+        @scenario.households_insulation_level_detached_houses_1985_2004 = 160.3984 * 0.9
+        @scenario.households_insulation_level_detached_houses_2005_present = 116.3707 * 0.9
+        @scenario.households_insulation_level_semi_detached_houses_before_1945 = 268.9665 * 0.9
+        @scenario.households_insulation_level_semi_detached_houses_1945_1964 = 217.0396 * 0.9
+        @scenario.households_insulation_level_semi_detached_houses_1965_1984 = 187.3579 * 0.9
+        @scenario.households_insulation_level_semi_detached_houses_1985_2004 = 154.0974 * 0.9
+        @scenario.households_insulation_level_semi_detached_houses_2005_present = 114.2388 * 0.9
+        @scenario.households_insulation_level_terraced_houses_before_1945 = 305.0056 * 0.9
+        @scenario.households_insulation_level_terraced_houses_1945_1964 = 280.6464 * 0.9
+        @scenario.households_insulation_level_terraced_houses_1965_1984 = 217.9607 * 0.9
+        @scenario.households_insulation_level_terraced_houses_1985_2004 = 150.8078 * 0.9
+        @scenario.households_insulation_level_terraced_houses_2005_present = 116.2858 * 0.9
 
         # setting residence slider back to their original values
-        @scenario.households_number_of_residences = 7587964
+        @scenario.households_number_of_apartments_before_1945 = 516342
+        @scenario.households_number_of_apartments_1945_1964 = 371806
+        @scenario.households_number_of_apartments_1965_1984 = 729999
+        @scenario.households_number_of_apartments_1985_2004 = 591948
+        @scenario.households_number_of_apartments_2005_present = 466180
+        @scenario.households_number_of_detached_houses_before_1945 = 178650
+        @scenario.households_number_of_detached_houses_1945_1964 = 175973
+        @scenario.households_number_of_detached_houses_1965_1984 = 333220
+        @scenario.households_number_of_detached_houses_1985_2004 = 223668
+        @scenario.households_number_of_detached_houses_2005_present = 105276
+        @scenario.households_number_of_semi_detached_houses_before_1945 = 237409
+        @scenario.households_number_of_semi_detached_houses_1945_1964 = 214301
+        @scenario.households_number_of_semi_detached_houses_1965_1984 = 606264
+        @scenario.households_number_of_semi_detached_houses_1985_2004 = 416081
+        @scenario.households_number_of_semi_detached_houses_2005_present = 173292
+        @scenario.households_number_of_terraced_houses_before_1945 = 622120
+        @scenario.households_number_of_terraced_houses_1945_1964 = 312200
+        @scenario.households_number_of_terraced_houses_1965_1984 = 504251
+        @scenario.households_number_of_terraced_houses_1985_2004 = 550888
+        @scenario.households_number_of_terraced_houses_2005_present = 258096
 
         # setting insulation sliders back to their original values
-        @scenario.households_insulation_level_apartments = 13
-        @scenario.households_insulation_level_corner_houses = 9
-        @scenario.households_insulation_level_detached_houses = 11
-        @scenario.households_insulation_level_semi_detached_houses = 13
-        @scenario.households_insulation_level_terraced_houses = 13
+        @scenario.households_insulation_level_apartments_before_1945 = 309.2785
+        @scenario.households_insulation_level_apartments_1945_1964 = 225.7048
+        @scenario.households_insulation_level_apartments_1965_1984 = 193.542
+        @scenario.households_insulation_level_apartments_1985_2004 = 154.5946
+        @scenario.households_insulation_level_apartments_2005_present = 115.9263
+        @scenario.households_insulation_level_detached_houses_before_1945 = 296.1239
+        @scenario.households_insulation_level_detached_houses_1945_1964 = 243.2537
+        @scenario.households_insulation_level_detached_houses_1965_1984 = 202.5222
+        @scenario.households_insulation_level_detached_houses_1985_2004 = 160.3984
+        @scenario.households_insulation_level_detached_houses_2005_present = 116.3707
+        @scenario.households_insulation_level_semi_detached_houses_before_1945 = 268.9665
+        @scenario.households_insulation_level_semi_detached_houses_1945_1964 = 217.0396
+        @scenario.households_insulation_level_semi_detached_houses_1965_1984 = 187.3579
+        @scenario.households_insulation_level_semi_detached_houses_1985_2004 = 154.0974
+        @scenario.households_insulation_level_semi_detached_houses_2005_present = 114.2388
+        @scenario.households_insulation_level_terraced_houses_before_1945 = 305.0056
+        @scenario.households_insulation_level_terraced_houses_1945_1964 = 280.6464
+        @scenario.households_insulation_level_terraced_houses_1965_1984 = 217.9607
+        @scenario.households_insulation_level_terraced_houses_1985_2004 = 150.8078
+        @scenario.households_insulation_level_terraced_houses_2005_present = 116.2858
 
         # should then also give us their initial values
         expect(@scenario.turk_hhp_network_gas_input_share.increase).to be == 0.0
         expect(@scenario.turk_hhp_electricity_input_share.increase).to be == 0.0
-        # for the ambient_heat input share we have a very small deviation as explained in line 21-22
+        # for the ambient_heat input share we have a very small deviation as explained in line 44-45
         expect(@scenario.turk_hhp_ambient_heat_input_share.increase).to be < 1.0E-12
 
       end
@@ -83,12 +208,40 @@ describe "Hybrid heat pump" do
     describe "Setting the relevant HHP sliders" do
 
     it "should change the shares of gas, electricity and ambient_heat by the correct amount" do
+      skip("ETEngine #1398")
         # increase insulation levels
-        @scenario.households_insulation_level_apartments = 15
-        @scenario.households_insulation_level_corner_houses = 11
-        @scenario.households_insulation_level_detached_houses = 13
-        @scenario.households_insulation_level_semi_detached_houses = 15
-        @scenario.households_insulation_level_terraced_houses = 15
+
+        # @scenario.households_insulation_level_apartments = 15
+        # for nl start value is 13
+        # @scenario.households_insulation_level_corner_houses = 11
+        # for nl start value is 9
+        # @scenario.households_insulation_level_detached_houses = 13
+        # for nl start value is 11
+        # @scenario.households_insulation_level_semi_detached_houses = 15
+        # for nl start value is 13
+        # @scenario.households_insulation_level_terraced_houses = 15
+        # for nl start value is 13
+
+        @scenario.households_insulation_level_apartments_before_1945 = 309.2785 * (100.0 - 15.0) / (100.0 - 13.0)
+        @scenario.households_insulation_level_apartments_1945_1964 = 225.7048 * (100.0 - 15.0) / (100.0 - 13.0)
+        @scenario.households_insulation_level_apartments_1965_1984 = 193.542 * (100.0 - 15.0) / (100.0 - 13.0)
+        @scenario.households_insulation_level_apartments_1985_2004 = 154.5946 * (100.0 - 15.0) / (100.0 - 13.0)
+        @scenario.households_insulation_level_apartments_2005_present = 115.9263 * (100.0 - 15.0) / (100.0 - 13.0)
+        @scenario.households_insulation_level_detached_houses_before_1945 = 296.1239 * (100.0 - 13.0) / (100.0 - 11.0)
+        @scenario.households_insulation_level_detached_houses_1945_1964 = 243.2537 * (100.0 - 13.0) / (100.0 - 11.0)
+        @scenario.households_insulation_level_detached_houses_1965_1984 = 202.5222 * (100.0 - 13.0) / (100.0 - 11.0)
+        @scenario.households_insulation_level_detached_houses_1985_2004 = 160.3984 * (100.0 - 13.0) / (100.0 - 11.0)
+        @scenario.households_insulation_level_detached_houses_2005_present = 116.3707 * (100.0 - 13.0) / (100.0 - 11.0)
+        @scenario.households_insulation_level_semi_detached_houses_before_1945 = 268.9665 * (100.0 - 15.0) / (100.0 - 13.0)
+        @scenario.households_insulation_level_semi_detached_houses_1945_1964 = 217.0396 * (100.0 - 15.0) / (100.0 - 13.0)
+        @scenario.households_insulation_level_semi_detached_houses_1965_1984 = 187.3579 * (100.0 - 15.0) / (100.0 - 13.0)
+        @scenario.households_insulation_level_semi_detached_houses_1985_2004 = 154.0974 * (100.0 - 15.0) / (100.0 - 13.0)
+        @scenario.households_insulation_level_semi_detached_houses_2005_present = 114.2388 * (100.0 - 15.0) / (100.0 - 13.0)
+        @scenario.households_insulation_level_terraced_houses_before_1945 = 305.0056 * (100.0 - 15.0) / (100.0 - 13.0)
+        @scenario.households_insulation_level_terraced_houses_1945_1964 = 280.6464 * (100.0 - 15.0) / (100.0 - 13.0)
+        @scenario.households_insulation_level_terraced_houses_1965_1984 = 217.9607 * (100.0 - 15.0) / (100.0 - 13.0)
+        @scenario.households_insulation_level_terraced_houses_1985_2004 = 150.8078 * (100.0 - 15.0) / (100.0 - 13.0)
+        @scenario.households_insulation_level_terraced_houses_2005_present = 116.2858 * (100.0 - 15.0) / (100.0 - 13.0)
 
         # we expect the gas share to decrease due to insulation and
         # the decrease in number of houses (and hence, a decrease in network gas demand)
@@ -158,14 +311,6 @@ describe "Hybrid heat pump" do
     describe "HHP for hot water with cut-off COP of 6.0" do
       it "should result in more gas use by HHP's" do
        @scenario.households_useful_demand_hot_water_share = 5.0
-
-       expect(@scenario.turk_hhp_network_gas_input_share).to increase
-      end
-    end
-
-    describe "Increasing the demand for space heating" do
-      it "should result in more gas use by HHP's" do
-       @scenario.households_useful_demand_heat_per_person = 5.0
 
        expect(@scenario.turk_hhp_network_gas_input_share).to increase
       end

--- a/spec/demand/number_of_residences_spec.rb
+++ b/spec/demand/number_of_residences_spec.rb
@@ -10,30 +10,21 @@ describe "Sliders: shares of apartments, terraced houses, etc. " do
   context "Removing all apartments and insulating them" do
 
     it "should leave the cost unchanged" do
-      # move slider 1 (number of old houses in millions)
-      @scenario.households_apartments_share = 0.0
+      # move slider set 1 (number of apartments)
+      @scenario.households_number_of_apartments_before_1945 = 0.0
+      @scenario.households_number_of_apartments_1945_1964 = 0.0
+      @scenario.households_number_of_apartments_1965_1984 = 0.0
+      @scenario.households_number_of_apartments_1985_2004 = 0.0
+      @scenario.households_number_of_apartments_2005_present = 0.0
 
       @scenario.refresh!
 
-      # move slider 2 (insulation of old houses)
-      @scenario.households_insulation_level_apartments = 65.0
-
-      @scenario.costs.increase.should == 0
-
-    end
-
-  end
-
-  context "Removing all corner houses and insulating them" do
-
-    it "should leave the cost unchanged" do
-      # move slider 1 (number of new houses in millions)
-      @scenario.households_corner_houses_share = 0.0
-
-      @scenario.refresh!
-
-      # move slider 2 (insulation of new houses)
-      @scenario.households_insulation_level_corner_houses = 65.0
+      # move slider set 2 (level of insulation in apartments)
+      @scenario.households_insulation_level_apartments_before_1945 = 309.2785 * 0.7
+      @scenario.households_insulation_level_apartments_1945_1964 = 225.7048 * 0.7
+      @scenario.households_insulation_level_apartments_1965_1984 = 193.542 * 0.7
+      @scenario.households_insulation_level_apartments_1985_2004 = 154.5946 * 0.7
+      @scenario.households_insulation_level_apartments_2005_present = 115.9263 * 0.7
 
       @scenario.costs.increase.should == 0
 
@@ -44,13 +35,21 @@ describe "Sliders: shares of apartments, terraced houses, etc. " do
   context "Removing all detached houses and insulating them" do
 
     it "should leave the cost unchanged" do
-      # move slider 1 (number of old houses in millions)
-      @scenario.households_detached_houses_share = 0.0
+      # move slider set 1 (number of detached houses)
+      @scenario.households_number_of_detached_houses_before_1945 = 0.0
+      @scenario.households_number_of_detached_houses_1945_1964 = 0.0
+      @scenario.households_number_of_detached_houses_1965_1984 = 0.0
+      @scenario.households_number_of_detached_houses_1985_2004 = 0.0
+      @scenario.households_number_of_detached_houses_2005_present = 0.0
 
       @scenario.refresh!
 
-      # move slider 2 (insulation of old houses)
-      @scenario.households_insulation_level_detached_houses = 65.0
+      # move slider set 2 (level of insulation in detached houses)
+      @scenario.households_insulation_level_detached_houses_before_1945 = 296.1239 * 0.7
+      @scenario.households_insulation_level_detached_houses_1945_1964 = 243.2537 * 0.7
+      @scenario.households_insulation_level_detached_houses_1965_1984 = 202.5222 * 0.7
+      @scenario.households_insulation_level_detached_houses_1985_2004 = 160.3984 * 0.7
+      @scenario.households_insulation_level_detached_houses_2005_present = 116.3707 * 0.7
 
       @scenario.costs.increase.should == 0
 
@@ -61,13 +60,21 @@ describe "Sliders: shares of apartments, terraced houses, etc. " do
   context "Removing all semi-detached houses and insulating them" do
 
     it "should leave the cost unchanged" do
-      # move slider 1 (number of old houses in millions)
-      @scenario.households_semi_detached_houses_share = 0.0
+      # move slider set 1 (number of semi-detached houses)
+      @scenario.households_number_of_semi_detached_houses_before_1945 = 0.0
+      @scenario.households_number_of_semi_detached_houses_1945_1964 = 0.0
+      @scenario.households_number_of_semi_detached_houses_1965_1984 = 0.0
+      @scenario.households_number_of_semi_detached_houses_1985_2004 = 0.0
+      @scenario.households_number_of_semi_detached_houses_2005_present = 0.0
 
       @scenario.refresh!
 
-      # move slider 2 (insulation of old houses)
-      @scenario.households_insulation_level_semi_detached_houses = 65.0
+      # move slider set 2 (level of insulation in semi-detached houses)
+      @scenario.households_insulation_level_semi_detached_houses_before_1945 = 268.9665 * 0.7
+      @scenario.households_insulation_level_semi_detached_houses_1945_1964 = 217.0396 * 0.7
+      @scenario.households_insulation_level_semi_detached_houses_1965_1984 = 187.3579 * 0.7
+      @scenario.households_insulation_level_semi_detached_houses_1985_2004 = 154.0974 * 0.7
+      @scenario.households_insulation_level_semi_detached_houses_2005_present = 114.2388 * 0.7
 
       @scenario.costs.increase.should == 0
 
@@ -78,13 +85,21 @@ describe "Sliders: shares of apartments, terraced houses, etc. " do
   context "Removing all terraced houses and insulating them" do
 
     it "should leave the cost unchanged" do
-      # move slider 1 (number of old houses in millions)
-      @scenario.households_terraced_houses_share = 0.0
+      # move slider set 1 (number of terraced houses)
+      @scenario.households_number_of_terraced_houses_before_1945 = 0.0
+      @scenario.households_number_of_terraced_houses_1945_1964 = 0.0
+      @scenario.households_number_of_terraced_houses_1965_1984 = 0.0
+      @scenario.households_number_of_terraced_houses_1985_2004 = 0.0
+      @scenario.households_number_of_terraced_houses_2005_present = 0.0
 
       @scenario.refresh!
 
-      # move slider 2 (insulation of old houses)
-      @scenario.households_insulation_level_terraced_houses = 65.0
+      # move slider set 2 (level of insulation in semi-detached houses)
+      @scenario.households_insulation_level_terraced_houses_before_1945 = 305.0056 * 0.7
+      @scenario.households_insulation_level_terraced_houses_1945_1964 = 280.6464 * 0.7
+      @scenario.households_insulation_level_terraced_houses_1965_1984 = 217.9607 * 0.7
+      @scenario.households_insulation_level_terraced_houses_1985_2004 = 150.8078 * 0.7
+      @scenario.households_insulation_level_terraced_houses_2005_present = 116.2858 * 0.7
 
       @scenario.costs.increase.should == 0
 
@@ -96,13 +111,31 @@ describe "Sliders: shares of apartments, terraced houses, etc. " do
 
     it "should halve the heat demand for all housing types" do
       # move slider
-      @scenario.households_number_of_residences = 7587964 * 0.5
+      @scenario.households_number_of_apartments_before_1945 = 516342 * 0.5
+      @scenario.households_number_of_apartments_1945_1964 = 371806 * 0.5
+      @scenario.households_number_of_apartments_1965_1984 = 729999 * 0.5
+      @scenario.households_number_of_apartments_1985_2004 = 591948 * 0.5
+      @scenario.households_number_of_apartments_2005_present = 466180 * 0.5
+      @scenario.households_number_of_detached_houses_before_1945 = 178650 * 0.5
+      @scenario.households_number_of_detached_houses_1945_1964 = 175973 * 0.5
+      @scenario.households_number_of_detached_houses_1965_1984 = 333220 * 0.5
+      @scenario.households_number_of_detached_houses_1985_2004 = 223668 * 0.5
+      @scenario.households_number_of_detached_houses_2005_present = 105276 * 0.5
+      @scenario.households_number_of_semi_detached_houses_before_1945 = 237409 * 0.5
+      @scenario.households_number_of_semi_detached_houses_1945_1964 = 214301 * 0.5
+      @scenario.households_number_of_semi_detached_houses_1965_1984 = 606264 * 0.5
+      @scenario.households_number_of_semi_detached_houses_1985_2004 = 416081 * 0.5
+      @scenario.households_number_of_semi_detached_houses_2005_present = 173292 * 0.5
+      @scenario.households_number_of_terraced_houses_before_1945 = 622120 * 0.5
+      @scenario.households_number_of_terraced_houses_1945_1964 = 312200 * 0.5
+      @scenario.households_number_of_terraced_houses_1965_1984 = 504251 * 0.5
+      @scenario.households_number_of_terraced_houses_1985_2004 = 550888 * 0.5
+      @scenario.households_number_of_terraced_houses_2005_present = 258096 * 0.5
 
-      expect(@scenario.households_apartments_useful_demand_for_space_heating.value).to be_within(1000.0).of(31685528434.883976)
-      expect(@scenario.households_corner_houses_useful_demand_for_space_heating.value).to be_within(1000.0).of(19755947635.17416)
-      expect(@scenario.households_detached_houses_useful_demand_for_space_heating.value).to be_within(1000.0).of(31668210840.305424)
-      expect(@scenario.households_semi_detached_houses_useful_demand_for_space_heating.value).to be_within(1000.0).of(15696965829.126356)
-      expect(@scenario.households_terraced_houses_useful_demand_for_space_heating.value).to be_within(1000.0).of(37689104723.15965)
+      expect(@scenario.households_apartments_useful_demand_for_space_heating.value).to be_within(1000.0).of(46896875253.5571)
+      expect(@scenario.households_detached_houses_useful_demand_for_space_heating.value).to be_within(1000.0).of(30193624312.9506)
+      expect(@scenario.households_semi_detached_houses_useful_demand_for_space_heating.value).to be_within(1000.0).of(41186001795.5793)
+      expect(@scenario.households_terraced_houses_useful_demand_for_space_heating.value).to be_within(1000.0).of(18192325710.2462)
 
     end
 
@@ -113,7 +146,10 @@ describe "Sliders: shares of apartments, terraced houses, etc. " do
 
     it "should double the residential roof surface available for pv" do
       # move slider to the doubled number of residences
-      @scenario.households_number_of_residences = 7587964 * 2
+      @scenario.households_number_of_apartments_future = 2676275.0
+      @scenario.households_number_of_detached_houses_future = 1016787.0
+      @scenario.households_number_of_semi_detached_houses_future = 1647347.0
+      @scenario.households_number_of_terraced_houses_future = 2247555.0
 
       expect(@scenario.turk_roof_surface_available_pv.value).to be_within(1.0).of 290.6
 

--- a/spec/demand/population_spec.rb
+++ b/spec/demand/population_spec.rb
@@ -22,19 +22,19 @@ describe "Population" do
   end
 
   it "should not increase the heat demand for old and new houses" do
-    expect(@scenario.heat_demand_in_households).to not_change
+    expect(@scenario.turk_heat_demand_in_households).to not_change
   end
 
   it "should not increase the cooling demand for old and new houses" do
-    expect(@scenario.cooling_demand_in_households.increase).to be == 0
+    expect(@scenario.turk_cooling_demand_in_households.increase).to be == 0
   end
 
   it "should increase the electricity demand in hh" do
-    expect(@scenario.appliances_demand_in_households).to increase
+    expect(@scenario.turk_appliances_demand_in_households).to increase
   end
 
   it "should increase the hot water demand in hh" do
-    expect(@scenario.hot_water_demand_in_households).to increase
+    expect(@scenario.turk_hot_water_demand_in_households).to increase
   end
 
 

--- a/spec/network/network_infrastructure_investments_spec.rb
+++ b/spec/network/network_infrastructure_investments_spec.rb
@@ -90,7 +90,7 @@ describe "Starting with a scenario where all household space heating is electric
 
     context "when local production with solar PV increases" do
       it "should decrease all network total cost" do
-        @scenario.households_solar_pv_solar_radiation_market_penetration = 100.0
+        @scenario.capacity_of_households_solar_pv_solar_radiation = 37400.0
 
         expect(@scenario.network_calculation_total_costs_future).to decrease
       end


### PR DESCRIPTION
This PR adjust the Mechanical Turk specs to match the change in the modelling of built environment heat in:

- https://github.com/quintel/fever/pull/1
- https://github.com/quintel/refinery/pull/61
- https://github.com/quintel/atlas/pull/164
- https://github.com/quintel/etengine/pull/1386
- https://github.com/quintel/etsource/pull/2997
- https://github.com/quintel/etmodel/pull/4193
- https://github.com/quintel/etdataset/pull/989
- https://github.com/quintel/etlocal/pull/503

One test in the hybrid_heatpump_spec is temporarily deactivated and should be updated. It tested whether inputs of hybrid heat pumps changed with increased insulation. This turned out to be caused by changes in the insulation curves. Since this feature is not part of the new heat modelling, the behaviour does not exist any more. See https://github.com/quintel/etengine/issues/1398#issuecomment-1954230437. The test needs to be rewritten.

- [x] Open an isse on mechanical_turk to either remove the skipped test in hybrid_heatpump_spec or write a new version

This PR also fixes a test in https://github.com/quintel/mechanical_turk/blob/master/spec/network/network_infrastructure_investments_spec.rb related to https://github.com/quintel/etsource/pull/3005. The solar PV is no longer set as market penetration in %, but as capacity in MW.