### PR TITLE
 Fixing spec for hybrid oil heatpumps

### DIFF
--- a/spec/demand/hybrid_heatpump_spec.rb
+++ b/spec/demand/hybrid_heatpump_spec.rb
@@ -258,7 +258,7 @@ describe "Hybrid heat pump" do
     before do
       @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, autobalance: true, inputs: {
       households_heater_hybrid_heatpump_air_water_electricity_share: 100.0, #setting HHP's for space heating and hot water to 100%,
-      flexibility_heat_pump_space_heating_cop_cutoff: 6.0, # setting the cut-off COP to 6.0
+      flexibility_heat_pump_space_heating_cop_cutoff_gas: 6.0, # setting the cut-off COP to 6.0
       flexibility_heat_pump_water_heating_cop_cutoff: 6.0 # setting the cut-off COP to 6.0
       })
     end
@@ -292,7 +292,7 @@ describe "Hybrid heat pump" do
 
     describe "Lowering the cut-off COP for space heating to 1.0" do
       it "should result in less gas use for space heating" do
-        @scenario.flexibility_heat_pump_space_heating_cop_cutoff = 1.0
+        @scenario.flexibility_heat_pump_space_heating_cop_cutoff_gas = 1.0
 
         expect(@scenario.natural_gas_and_derivatives_used_for_heating_in_households). to decrease
       end
@@ -303,7 +303,7 @@ describe "Hybrid heat pump" do
     before do
       @scenario = Turk::Scenario.new(area_code: "nl", end_year: 2050, autobalance: true, inputs: {
       households_heater_hybrid_heatpump_air_water_electricity_share: 100.0, #setting HHP's for space heating and hot water to 100%,
-      flexibility_heat_pump_space_heating_cop_cutoff: 1.0, # setting the cut-off COP to 1.0
+      flexibility_heat_pump_space_heating_cop_cutoff_gas: 1.0, # setting the cut-off COP to 1.0
       flexibility_heat_pump_water_heating_cop_cutoff: 1.0 # setting the cut-off COP to 1.0
       })
     end


### PR DESCRIPTION
Changing the share used for checking the hybrid heatpump specs compliant with the namechange for `flexibility_heat_pump_space_heating_cop_cutoff ` 
to `flexibility_heat_pump_space_heating_cop_cutoff_gas`.
