### PR TITLE
Direct emissions spec

### DIFF
--- a/query_sources.yml
+++ b/query_sources.yml
@@ -18,6 +18,7 @@ turk_queries:
     - spec/mekko/mekko_supply_demand_spec.rb
     - spec/supply/ccus_spec.rb
     - spec/supply/electricity_sankey_spec.rb
+    - spec/emissions/direct_emissions.rb
 
 # NEW GROUP EXAMPLE
 # -----------------

--- a/spec/emissions/direct_emissions.rb
+++ b/spec/emissions/direct_emissions.rb
@@ -1,0 +1,43 @@
+# Tests direct emissions method results
+
+require 'spec_helper'
+
+RSpec.describe 'Direct emissions' do
+  Turk::PresetCollection.from_keys(:ii3050v2, :kev, :scenario_collection).each do |scenario|
+    context "with scenario #{scenario.original_scenario_id}" do
+      # Test correctness of scenario's total GHG emissions. A failing test indicates that the
+      # sector_label might not have been added to a node or that the per sector GHG queries are
+      # not complete.
+      it "sum of total GHG emissions of all nodes should equal the sum of total GHG emissions per
+        sector" do
+        expect(
+          scenario.turk_direct_emissions_total_ghg_all_nodes
+        ).to softly_equal(
+          scenario.turk_direct_emissions_total_ghg_incl_indirect_emissions_lulucf_bunkers
+        )
+      end
+
+      # Test correctness of the sum of the total CO2 and total other GHG query match the total
+      # GHG query, incl. indirect emissions, LULUCF, bunkers.
+      it "sum of totals query for CO2 and other GHG (incl. indirect emissions, LULUCF, bunkers)
+        should equal the total GHG query" do
+        expect(
+          scenario.turk_direct_emissions_sum_co2_other_ghg_incl_indirect_emissions_lulucf_bunkers
+        ).to softly_equal(
+          scenario.turk_direct_emissions_total_ghg_incl_indirect_emissions_lulucf_bunkers
+        )
+      end
+
+      # Test correctness of the sum of the total CO2 and total other GHG query match the total
+      # GHG query, excl. indirect emissions, LULUCF, bunkers.
+      it "sum of totals query for CO2 and other GHG (excl. indirect emissions, LULUCF, bunkers)
+        should equal the total GHG query" do
+        expect(
+          scenario.turk_direct_emissions_sum_co2_other_ghg_excl_indirect_emissions_lulucf_bunkers
+        ).to softly_equal(
+          scenario.turk_direct_emissions_total_ghg_excl_indirect_emissions_lulucf_bunkers
+        )
+      end
+    end
+  end
+end

--- a/spec/emissions/direct_emissions.rb
+++ b/spec/emissions/direct_emissions.rb
@@ -38,6 +38,37 @@ RSpec.describe 'Direct emissions' do
           scenario.turk_direct_emissions_total_ghg_excl_indirect_emissions_lulucf_bunkers
         )
       end
+
+      # Totals of IPCC queries should match ETM sector totals
+      it "IPCC total emissions should match ETM sector total emissions (incl indirect emissions,
+        lulucf and bunkers)" do
+        expect(
+          scenario.turk_direct_emissions_ipcc_total_ghg_incl_indirect_emissions_lulucf_bunkers
+        ).to softly_equal(
+          scenario.turk_direct_emissions_total_ghg_incl_indirect_emissions_lulucf_bunkers
+        )
+      end
+
+      # Totals of IPCC queries should match ETM sector totals
+      it "IPCC total emissions should match ETM sector total emissions (excl indirect emissions,
+        lulucf and bunkers)" do
+        expect(
+          scenario.turk_direct_emissions_ipcc_total_ghg_excl_indirect_emissions_lulucf_bunkers
+        ).to softly_equal(
+          scenario.turk_direct_emissions_total_ghg_excl_indirect_emissions_lulucf_bunkers
+        )
+      end
+
+      # Test correctness of the sum of the total IPCC CO2 and total other GHG query match the total
+      # IPCC GHG query, incl. indirect emissions, LULUCF, bunkers.
+      it "sum of IPCC totals query for CO2 and other GHG (incl. indirect emissions, LULUCF, bunkers)
+        should equal the IPCC total GHG query" do
+        expect(
+          scenario.turk_direct_emissions_ipcc_co2_other_ghg_incl_indirect_emissions_lulucf_bunkers
+        ).to softly_equal(
+          scenario.turk_direct_emissions_ipcc_total_ghg_incl_indirect_emissions_lulucf_bunkers
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
#### Context
This PR adds a spec for direct emissions tests. 

#### Implemented changes
- Tests for ETM sector-related emission totals
- Tests for IPCC-related emission totals

#### Related

Goes with:
- https://github.com/quintel/etsource/pull/3466
- https://github.com/quintel/etmodel/pull/4760
- https://github.com/quintel/mechanical_turk/pull/220

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
